### PR TITLE
Bump to make-up 6 and change tests to chai expect

### DIFF
--- a/lib/cacheWrapper.js
+++ b/lib/cacheWrapper.js
@@ -1,4 +1,3 @@
-/* jslint node: true */
 'use strict';
 
 var cacheWrapper = module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-wrapper",
   "description": "System aggregator and data logic layer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/holidayextras/cache-wrapper",
   "author": {
     "name": "Shortbreaks",
@@ -32,11 +32,8 @@
     "chai": "2.2.0",
     "chai-as-promised": "5.1.0",
     "deployment-helpers": "git+ssh://git@github.com:holidayextras/deployment-helpers.git",
-    "grunt": "0.4.4",
-    "grunt-contrib-jshint": "0.10.0",
-    "grunt-jscs": "0.8.1",
     "istanbul": "0.3.7",
-    "make-up": "5.3.1",
+    "make-up": "6.0.0",
     "mocha": "1.21.3",
     "sinon": "1.11.1"
   }

--- a/test/lib/cacheWrapperTest.js
+++ b/test/lib/cacheWrapperTest.js
@@ -1,14 +1,11 @@
-/* jslint node: true */
-/* jshint -W030 */ // Handle "Expected an assignment or function call and instead saw an expression" errors
 'use strict';
 
 process.env.NODE_ENV = 'development';
 
 var cache = require( '../../lib/cacheWrapper' );
 var chai = require( 'chai' );
-var chaiAsPromised = require( 'chai-as-promised' );
-chai.should();
-chai.use( chaiAsPromised );
+chai.use( require( 'chai-as-promised' ) );
+var expect = chai.expect;
 
 var Catbox = require( 'catbox' );
 
@@ -49,35 +46,35 @@ var startStub;
 describe( 'Cache', function() {
 
   it( 'should fail to set an item in the cache before it has initialised', function() {
-    return cache.set( cacheItem ).should.be.rejected;
+    return expect( cache.set( cacheItem ) ).to.be.rejected;
   } );
 
   it( 'should initialise the cache', function() {
-    return cache.initialise( serverConfig, policies ).should.be.fulfilled;
+    return expect( cache.initialise( serverConfig, policies ) ).to.be.fulfilled;
   } );
 
   it( 'should set an item in the cache', function() {
-    return cache.set( cacheItem ).should.be.fulfilled;
+    return expect( cache.set( cacheItem ) ).to.be.fulfilled;
   } );
 
   it( 'should get the item from the cache', function() {
-    return cache.get( cacheItem ).should.be.fulfilled.and.should.eventually.equal( cacheItem.value );
+    return expect( cache.get( cacheItem ) ).to.be.fulfilled.and.to.eventually.equal( cacheItem.value );
   } );
 
   it( 'should fail to get a non-existant item from the cache', function() {
-    return cache.get( nonExistantCacheItem ).should.be.rejected;
+    return expect( cache.get( nonExistantCacheItem ) ).to.be.rejected;
   } );
 
   it( 'should fail to get a non-existant policy item from the cache', function() {
-    return cache.get( nonExistantCachePolicy ).should.be.rejected;
+    return expect( cache.get( nonExistantCachePolicy ) ).to.be.rejected;
   } );
 
   it( 'should fail to set an item in a non-existant policy', function() {
-    return cache.set( nonExistantCachePolicy ).should.be.rejected;
+    return expect( cache.set( nonExistantCachePolicy ) ).to.be.rejected;
   } );
 
   it( 'should fail to set an item that is broken', function() {
-    return cache.set( brokenCacheItem ).should.be.rejected;
+    return expect( cache.set( brokenCacheItem ) ).to.be.rejected;
   } );
 
   context( 'Cache not ready, queue it', function() {
@@ -93,11 +90,11 @@ describe( 'Cache', function() {
     } );
 
     it( 'should queue and then set an item in the cache', function() {
-      return cache.set( cacheItem ).should.be.fulfilled;
+      return expect( cache.set( cacheItem ) ).to.be.fulfilled;
     } );
 
     it( 'should queue and then get an item from the cache', function() {
-      return cache.get( cacheItem ).should.be.fulfilled.and.should.eventually.equal( cacheItem.value );
+      return expect( cache.get( cacheItem ) ).to.be.fulfilled.and.to.eventually.equal( cacheItem.value );
     } );
 
   } );
@@ -119,11 +116,11 @@ describe( 'Cache', function() {
     } );
 
     it( 'should fail to queue and then set an item in the cache', function() {
-      return cache.set( cacheItem ).should.be.rejected;
+      return expect( cache.set( cacheItem ) ).to.be.rejected;
     } );
 
     it( 'should fail to queue and then get an item from the cache', function() {
-      return cache.get( cacheItem ).should.be.rejected;
+      return expect( cache.get( cacheItem ) ).to.be.rejected;
     } );
 
   } );


### PR DESCRIPTION
#### What are the links to relevant tickets?

https://hxshortbreaks.atlassian.net/browse/WEB-6516
#### What does this PR do?

Updates to latest make-up (6.0)

Swaps out the use of should to expect as per the current culture guidelines https://github.com/holidayextras/culture/blob/master/testing-standard.md
#### What functional/unit tests does this PR have?

Same as before, what were you expecting?
#### How should a developer review this?

Read through
#### Any background context you want to provide?
#### Screenshots (if appropriate)

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [ ] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.
#### Reviewer 1 @kevinhodges
- [x] I agree with the assumptions made in the quality checklist.
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
#### Reviewer 2 @notABluesSinger
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
