### PR TITLE
web7842 continue to scan redis until zero cursor is returned

### DIFF
--- a/lib/cacheWrapper.js
+++ b/lib/cacheWrapper.js
@@ -209,4 +209,3 @@ cacheWrapper.delete = function(options) {
     Q.resolve('Redis cache drop failed');
   });
 };
-

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -40,17 +40,15 @@ redisWrapper.scan = function(options) {
     return Q.reject('Required options not passed in');
   }
   options.keys = [];
+  options.newCursor = 0;
   // do stuff that Catbox used to do for us
   var cacheNamespace = options.partition + separator + encodeURIComponent(options.segment) + separator;
   var prefix = cacheNamespace + encodeURIComponent(options.prefix) + wildcard;
-  // Scan iterates through the keys and returns the ones matching the given prefix
-  if (_.isUndefined(options.newCursor)) {
-    options.newCursor = 0;
-  }
-  return redisWrapper.recursiveScan(options, prefix, cacheNamespace, deferred);
+  return redisWrapper._recursiveScan(options, prefix, cacheNamespace, deferred);
 };
 
-redisWrapper.recursiveScan = function(options, prefix, cacheNamespace, deferred) {
+redisWrapper._recursiveScan = function(options, prefix, cacheNamespace, deferred) {
+  // Scan iterates through the keys and returns the ones matching the given prefix
   redisClient.scan(options.newCursor, 'MATCH', prefix, function (err, results) {
     if (err) {
       deferred.reject('Redis SCAN failed');
@@ -66,7 +64,7 @@ redisWrapper.recursiveScan = function(options, prefix, cacheNamespace, deferred)
       options.keys = options.keys.concat(keys);
       // if the scan has not finished searching all entries continue to scan again using the newCusor position to start
       if (options.newCursor > 0){
-        redisWrapper.recursiveScan(options, prefix, cacheNamespace, deferred);
+        redisWrapper._recursiveScan(options, prefix, cacheNamespace, deferred);
       } else {
         deferred.resolve(options);
       }

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -63,10 +63,10 @@ redisWrapper._recursiveScan = function(options, prefix, cacheNamespace, deferred
       // result is an array of 2 values the results[0] first value is the new cursor to use in the next call
       options.newCursor = results[0];
       // the second results[1] is the list of keys that match the pattern
-      var keys = (_.map(results[1], function(key) {
+      var keys = _.map(results[1], function(key) {
         // strip off the cache namespace
         return decodeURIComponent(key.replace(cacheNamespace, ''));
-      }));
+      });
       // push the found keys into the keys array to be returned after finidhing the scan.
       options.keys = options.keys.concat(keys);
       // if the scan has not finished searching all entries continue to scan again using the newCusor position to start

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -50,8 +50,9 @@ redisWrapper.scan = function(options) {
 * Using SCAN here and not KEYS to avoid blocking the server for a long time when called against big collections of keys or elements.
 * @param {Object} options - Including keys,newCursor.
 * @param {Object} prefix - cache fields to match.
-* @returns {Object} cacheNamespace - cache namespace
-* @returns {Object} promise
+* @param {Object} cacheNamespace - cache namespace.
+* @param {Object} deferred - A promise to manage flow.
+* @returns {Object} promise - A promise.
 */
 redisWrapper._recursiveScan = function(options, prefix, cacheNamespace, deferred) {
   // Scan iterates through the keys and returns the ones matching the given prefix

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -27,7 +27,6 @@ redisWrapper.initialise = function(serverConfig) {
 };
 /**
 * Allows you to retrieve a keys which have a value matching the pattern passed in prefix.
-* Using SCAN here and not KEYS to avoid blocking the server for a long time when called against big collections of keys or elements.
 * @param {Object} options - Including partition,segment,prefix.
 * @returns {Object} promise
 */
@@ -46,7 +45,14 @@ redisWrapper.scan = function(options) {
   var prefix = cacheNamespace + encodeURIComponent(options.prefix) + wildcard;
   return redisWrapper._recursiveScan(options, prefix, cacheNamespace, deferred);
 };
-
+/**
+* Allows you to recursively retrieve all keys which have a value matching the pattern passed in prefix.
+* Using SCAN here and not KEYS to avoid blocking the server for a long time when called against big collections of keys or elements.
+* @param {Object} options - Including keys,newCursor.
+* @param {Object} prefix - cache fields to match.
+* @returns {Object} cacheNamespace - cache namespace
+* @returns {Object} promise
+*/
 redisWrapper._recursiveScan = function(options, prefix, cacheNamespace, deferred) {
   // Scan iterates through the keys and returns the ones matching the given prefix
   redisClient.scan(options.newCursor, 'MATCH', prefix, function (err, results) {

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -19,7 +19,7 @@ redisWrapper.initialise = function(serverConfig) {
     });
     // if there was error connecting to redis server
     redisClient.on('error', function () {
-      deferred.reject( 'Error trying to connect to redis server');
+      deferred.reject('Error trying to connect to redis server');
     });
 
   }
@@ -39,22 +39,37 @@ redisWrapper.scan = function(options) {
     || _.isUndefined(options.prefix)) {
     return Q.reject('Required options not passed in');
   }
+  options.keys = [];
   // do stuff that Catbox used to do for us
   var cacheNamespace = options.partition + separator + encodeURIComponent(options.segment) + separator;
   var prefix = cacheNamespace + encodeURIComponent(options.prefix) + wildcard;
   // Scan iterates through the keys and returns the ones matching the given prefix
-  redisClient.scan(0, 'MATCH', prefix, function (err, results) {
+  if (_.isUndefined(options.newCursor)) {
+    options.newCursor = 0;
+  }
+  return redisWrapper.recursiveScan(options, prefix, cacheNamespace, deferred);
+};
+
+redisWrapper.recursiveScan = function(options, prefix, cacheNamespace, deferred) {
+  redisClient.scan(options.newCursor, 'MATCH', prefix, function (err, results) {
     if (err) {
-      deferred.reject( 'Redis SCAN failed' );
+      deferred.reject('Redis SCAN failed');
     } else {
-      // result is an array of 2 values the results[0] first value is the new cursor to use in the next call,
-      // the second results[1] is the list of keys that match the pattern which we are interested in
-      options.keys = _.map(results[1], function(key) {
+      // result is an array of 2 values the results[0] first value is the new cursor to use in the next call
+      options.newCursor = results[0];
+      // the second results[1] is the list of keys that match the pattern
+      var keys = (_.map(results[1], function(key) {
         // strip off the cache namespace
         return decodeURIComponent(key.replace(cacheNamespace, ''));
-      });
-
-      deferred.resolve(options);
+      }));
+      // push the found keys into the keys array to be returned after finidhing the scan.
+      options.keys = options.keys.concat(keys);
+      // if the scan has not finished searching all entries continue to scan again using the newCusor position to start
+      if (options.newCursor > 0){
+        redisWrapper.recursiveScan(options, prefix, cacheNamespace, deferred);
+      } else {
+        deferred.resolve(options);
+      }
     }
   });
   return deferred.promise;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-wrapper",
   "description": "System aggregator and data logic layer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/holidayextras/cache-wrapper",
   "author": {
     "name": "Shortbreaks",

--- a/test/lib/redisWrapperTest.js
+++ b/test/lib/redisWrapperTest.js
@@ -93,7 +93,7 @@ describe('redisWrapper', function() {
 
     describe('when required options is passed and redisClient does not error', function() {
       beforeEach(function() {
-        recursiveScanStub = sandbox.stub(redisWrapper, 'recursiveScan', function(scanOptions) {
+        recursiveScanStub = sandbox.stub(redisWrapper, '_recursiveScan', function(scanOptions) {
           scanOptions.keys = ['key1', 'key2'];
           return Q.resolve(scanOptions);
         });
@@ -117,7 +117,7 @@ describe('redisWrapper', function() {
             scan: getStub
           }
         });
-        redisWrapper.recursiveScan(recursiveScanOptions, 'testPrefix', 'cacheNamespace', deferred);
+        redisWrapper._recursiveScan(recursiveScanOptions, 'testPrefix', 'cacheNamespace', deferred);
       });
       it('returns with the keys that match the prefix', function() {
         expect(getStub).to.be.calledOnce();
@@ -136,8 +136,7 @@ describe('redisWrapper', function() {
             scan: getStub
           }
         });
-        redisWrapper.recursiveScan(recursiveScanOptions, 'testPrefix', 'cacheNamespace', deferred);
-
+        redisWrapper._recursiveScan(recursiveScanOptions, 'testPrefix', 'cacheNamespace', deferred);
       });
       it('returns with the keys that match the prefix', function() {
         expect(getStub).to.be.calledTwice();


### PR DESCRIPTION
#### What are the links to relevant tickets?

https://hxshortbreaks.atlassian.net/browse/WEB-7842
#### What does this PR do?

makes sure the scan function completes the iteration (the cursor returned is 0)
#### What functional/unit tests does this PR have?

 scan
      when required options is not passed 
        ✓ rejects the promise
      when required options is passed and redisClient does not error
        ✓ returns with the keys that match the prefix
    recursiveScan
      when required options is passed and redisClient errors
        ✓ returns with the keys that match the prefix
      when required options is passed and redisClient does not error
        ✓ returns with the keys that match the prefix
#### Is there anything a developer should be aware of when reviewing this?

You can test the  cache set and get work by  by running revolver branch web7843(This is still WIP)  locally and
revolver availability should have a cache hit when you try the availability request multiple times
when redis is running locally it should still come back with availability when redis is not running locally but should have cache miss in the metric logs.
http://localhost:8001/theme/availability?agent=LGD01&adults=2&children=2&infants=0&customerCode=T&location=LLW&nights=1&program=WIN&commissionGroup=Default&referrer=legoland&exposeProviderCodes=true&room%5B0%5D%5BoccupancyType%5D=QUAD&room%5B0%5D%5Badults%5D=2&room%5B0%5D%5ByoungAdults%5D=0&room%5B0%5D%5Bchildren%5D=2&room%5B0%5D%5Binfants%5D=0&identifier=YBR&arrivalDate=2016-08-24&ticketDate=2016-08-24&_=1469179163536

To test the cache drop you can try making a booking on web7843 branch of revolver locally (This is still WIP) and you should be able to see in your local redis-cli  using 'keys *' command to see the keys being added on availability request and  the keys being deleted on booking( opera/ chaunrty ones depending on the  booking made).
#### Screenshots (if appropriate)

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.
#### Reviewer 1 @reubensearle
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
#### Reviewer 2 @robhuzzey
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
