### PR TITLE
web7845 Adding count parameter to the redis scan command

### DIFF
--- a/lib/cacheWrapper.js
+++ b/lib/cacheWrapper.js
@@ -206,6 +206,6 @@ cacheWrapper.delete = function(options) {
   return redisWrapper.scan(options)
   .then(cacheWrapper._delete)
   .fail( function() {
-    Q.resolve('Redis cache drop failed');
+    return Q.resolve('Redis cache drop failed');
   });
 };

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -55,11 +55,12 @@ redisWrapper.scan = function(options) {
 * @returns {Object} promise - A promise.
 */
 redisWrapper._recursiveScan = function(options, prefix, cacheNamespace, deferred) {
+  console.log('here');
   // Scan iterates through the keys and returns the ones matching the given prefix
   // Scan has a default count of 10 meaning it will only scan 10 keys,
   // have set the count to 300 to reduce time it takes to scan the entire redis DB
   // Need to use caution if increaing the count, as it could cause the redis server to be blocked for a long time.
-  redisClient.scan(options.newCursor, 'MATCH', prefix, 'COUNT', '300', function (err, results) {
+  redisClient.scan(options.newCursor, 'MATCH', prefix, 'COUNT', 300, function (err, results) {
     if (err) {
       deferred.reject('Redis SCAN failed');
     } else {

--- a/lib/redisWrapper.js
+++ b/lib/redisWrapper.js
@@ -56,7 +56,10 @@ redisWrapper.scan = function(options) {
 */
 redisWrapper._recursiveScan = function(options, prefix, cacheNamespace, deferred) {
   // Scan iterates through the keys and returns the ones matching the given prefix
-  redisClient.scan(options.newCursor, 'MATCH', prefix, function (err, results) {
+  // Scan has a default count of 10 meaning it will only scan 10 keys,
+  // have set the count to 300 to reduce time it takes to scan the entire redis DB
+  // Need to use caution if increaing the count, as it could cause the redis server to be blocked for a long time.
+  redisClient.scan(options.newCursor, 'MATCH', prefix, 'COUNT', '300', function (err, results) {
     if (err) {
       deferred.reject('Redis SCAN failed');
     } else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-wrapper",
   "description": "System aggregator and data logic layer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/holidayextras/cache-wrapper",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
#### What are the links to relevant tickets?

https://hxshortbreaks.atlassian.net/browse/WEB-7845
#### What does this PR do?

Adds the count parameter to the scan command to reduce time taken to scan the entire redis DB
#### What functional/unit tests does this PR have?
#### Is there anything a developer should be aware of when reviewing this?

you can test this by running revolver branch web7845  with this version of cache-wrapper locally pointing to local redis.
On availability requests should see keys being added into cache and 
On book these should be removed from the cache.(will need to increase `expiresIn` in cachePolicies.json locally as it is set to 15s for the provider requests at the moment)
#### Screenshots (if appropriate)

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [x] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.
#### Reviewer 1 @robhuzzey
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
#### Reviewer 2 @hxpaul
- [x] I agree with the assumptions made in the quality checklist.
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
